### PR TITLE
Refactor to meet standardised Terraform structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ See the [examples/](examples/) folder.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=4.24.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >=2.6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >=4.24.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >=2.6.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,3 @@
-
 resource "helm_release" "aws_ebs" {
   name       = "aws-ebs-csi-driver"
   chart      = "aws-ebs-csi-driver"

--- a/versions.tf
+++ b/versions.tf
@@ -2,15 +2,11 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
+      version = ">=4.24.0"
     }
     helm = {
       source = "hashicorp/helm"
-    }
-    kubectl = {
-      source = "gavinbunney/kubectl"
+      version = ">=2.6.0"
     }
   }
   required_version = ">= 0.14"


### PR DESCRIPTION
This PR:

- runs terraform fmt
- removes unused kubernetes, kubectl providers
- adds minimum versions for providers