### PR TITLE
Kube 1.30 upgrade

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "helm_release" "aws_ebs" {
   chart      = "aws-ebs-csi-driver"
   repository = "https://kubernetes-sigs.github.io/aws-ebs-csi-driver"
   namespace  = "kube-system"
-  version    = "2.29.1"
+  version    = "2.41.0"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
   })]


### PR DESCRIPTION
Bump CSI to version 2.41.0 post kube 1.30 upgrade.